### PR TITLE
Updated to SDK 0.103

### DIFF
--- a/jetpack.c
+++ b/jetpack.c
@@ -251,16 +251,18 @@ static void jetpack_game_render_callback(Canvas* const canvas, void* ctx) {
     furi_mutex_release(game_state->mutex);
 }
 
-static void jetpack_game_input_callback(InputEvent* input_event, FuriMessageQueue* event_queue) {
-    furi_assert(event_queue);
+static void jetpack_game_input_callback(InputEvent* input_event, void* context) {
+    furi_assert(context);
 
+    FuriMessageQueue* event_queue = context;
     GameEvent event = {.type = EventTypeKey, .input = *input_event};
     furi_message_queue_put(event_queue, &event, FuriWaitForever);
 }
 
-static void jetpack_game_update_timer_callback(FuriMessageQueue* event_queue) {
-    furi_assert(event_queue);
+static void jetpack_game_update_timer_callback(void* context) {
+    furi_assert(context);
 
+    FuriMessageQueue* event_queue = context;
     GameEvent event = {.type = EventTypeTick};
     furi_message_queue_put(event_queue, &event, 0);
 }


### PR DESCRIPTION
`FuriMessageQueue` became a distinct type and not an alias to `void*`.